### PR TITLE
Complete the move from VPC peering to Transit Gateway (TGW) for partner connectivity and tidy the example for new partners.

### DIFF
--- a/tgw.tf
+++ b/tgw.tf
@@ -1,4 +1,9 @@
 # --- Accept the RAM share (one-time, after idOS adds your account) ---
+# You are in a different AWS Organization: idOS shares the TGW with your account ID;
+# you must accept the share (this resource, or manually in RAM → Shared with me).
+# If you see "No pending RAM Resource Share invitation found", the share was already
+# accepted (e.g. in the console). Import it instead of creating:
+#   terraform import aws_ram_resource_share_accepter.tgw "<tgw_ram_share_arn>"
 
 resource "aws_ram_resource_share_accepter" "tgw" {
   share_arn = var.tgw_ram_share_arn
@@ -26,5 +31,5 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 resource "aws_route" "to_tgw" {
   route_table_id         = aws_route_table.this.id
   destination_cidr_block = "10.0.0.0/8"
-  transit_gateway_id     = var.transit_gateway_id
+  transit_gateway_id     = aws_ec2_transit_gateway_vpc_attachment.this.transit_gateway_id
 }


### PR DESCRIPTION
## Summary

Complete the move from VPC peering to **Transit Gateway (TGW)** for partner connectivity and tidy the example for new partners.

## Changes

- **TGW:** Remove peering; add `tgw.tf` (RAM accepter, TGW attachment, route `10.0.0.0/8` → TGW). Route uses `aws_ec2_transit_gateway_vpc_attachment.this.transit_gateway_id`.
- **VPC / vars:** VPC uses `var.vpc_cidr`; one subnet per AZ. Drop `remote_*` and `cidr_block`; add `transit_gateway_id`, `tgw_ram_share_arn`, `vpc_cidr`.
- **Security group:** Allow 8484/6600 from `10.0.0.0/8`; restrict ICMP to `10.0.0.0/8`.
- **README:** TGW-only playbook for new partners; no partner names (idOS + Partner1/2/3 in CIDR table); less duplication; RAM/ARN examples use `XXXXXXXXXXXX`; add `docker network create kwil-dev` in node setup.
- **Docs:** Add `docs/horizen-tgw-migration-announcement.md` (message asking partners to migrate from peering to TGW).
- **Misc:** `terraform.tfvars` and `terraform.tfvars.example` updated for TGW; `outputs.tf` for TGW and instance IPs.